### PR TITLE
Sprint 11 : Gestion des Verbs non supportés

### DIFF
--- a/src/main/java/com/framework/controller/ErrorTestController.java
+++ b/src/main/java/com/framework/controller/ErrorTestController.java
@@ -1,0 +1,31 @@
+package com.framework.controller;
+
+import com.framework.annotation.Controller;
+import com.framework.annotation.GetMapping;
+import com.framework.annotation.PostMapping;
+import com.framework.modelview.ModelView;
+
+@Controller
+public class ErrorTestController {
+
+    @GetMapping("/error-test/form")
+    public ModelView showForm() {
+        return new ModelView("error-test.jsp");
+    }
+    
+    // Cette méthode ne supporte que GET
+    @GetMapping("/error-test/get-only")
+    public ModelView getOnlyEndpoint() {
+        ModelView mv = new ModelView("verb-test.jsp");
+        mv.addItem("responseMessage", "GET request successful");
+        return mv;
+    }
+
+    // Cette méthode ne supporte que POST
+    @PostMapping("/error-test/post-only")
+    public ModelView postOnlyEndpoint() {
+        ModelView mv = new ModelView("verb-test.jsp");
+        mv.addItem("responseMessage", "POST request successful");
+        return mv;
+    }
+}

--- a/src/main/java/com/framework/error/FrameworkException.java
+++ b/src/main/java/com/framework/error/FrameworkException.java
@@ -1,5 +1,7 @@
 package com.framework.error;
 
+import com.framework.http.HttpVerb;
+
 /**
  * Exception personnalisée pour le framework
  * Permet de gérer les différentes erreurs de manière uniforme
@@ -148,6 +150,16 @@ public class FrameworkException extends Exception {
             "Le paramètre '" + paramName + "' dans la méthode '" + methodName + 
             "' doit être annoté avec @RequestParam ou être un objet avec @RequestField",
             400
+        );
+    }
+
+    /**
+     * Verbe HTTP non supporté
+     */
+    public static FrameworkException verbNotSupported(HttpVerb verb, String url) {
+        return new FrameworkException(
+            String.format("Le verbe HTTP %s n'est pas supporté pour l'URL %s", verb, url),
+            404
         );
     }
 }

--- a/src/main/webapp/WEB-INF/views/error-404.jsp
+++ b/src/main/webapp/WEB-INF/views/error-404.jsp
@@ -1,0 +1,53 @@
+<%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<!DOCTYPE html>
+<html>
+<head>
+    <title>404 - Non trouvé</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            max-width: 800px;
+            margin: 50px auto;
+            padding: 20px;
+            text-align: center;
+        }
+        .error-code {
+            font-size: 72px;
+            color: #e74c3c;
+            margin: 0;
+        }
+        .error-message {
+            font-size: 24px;
+            color: #333;
+            margin: 20px 0;
+        }
+        .error-details {
+            color: #666;
+            margin: 20px 0;
+            padding: 15px;
+            background-color: #f8f9fa;
+            border-radius: 5px;
+        }
+        .home-link {
+            display: inline-block;
+            margin-top: 20px;
+            padding: 10px 20px;
+            background-color: #3498db;
+            color: white;
+            text-decoration: none;
+            border-radius: 5px;
+        }
+        .home-link:hover {
+            background-color: #2980b9;
+        }
+    </style>
+</head>
+<body>
+    <h1 class="error-code">404</h1>
+    <h2 class="error-message">Page non trouvée</h2>
+    <div class="error-details">
+        ${errorMessage}
+    </div>
+    <a href="${pageContext.request.contextPath}/app/" class="home-link">Retour à l'accueil</a>
+</body>
+</html>

--- a/src/main/webapp/WEB-INF/views/error-test.jsp
+++ b/src/main/webapp/WEB-INF/views/error-test.jsp
@@ -1,0 +1,25 @@
+<%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Test des erreurs 404</title>
+</head>
+<body>
+    <h1>Test des erreurs 404</h1>
+    
+    <h2>Test GET-only endpoint</h2>
+    <a href="${pageContext.request.contextPath}/app/error-test/get-only">Test GET (devrait fonctionner)</a>
+    <form action="${pageContext.request.contextPath}/app/error-test/get-only" method="post">
+        <input type="submit" value="Test POST (devrait échouer avec 404)">
+    </form>
+
+    <h2>Test POST-only endpoint</h2>
+    <a href="${pageContext.request.contextPath}/app/error-test/post-only">Test GET (devrait échouer avec 404)</a>
+    <form action="${pageContext.request.contextPath}/app/error-test/post-only" method="post">
+        <input type="submit" value="Test POST (devrait fonctionner)">
+    </form>
+
+    <h2>Test URL inexistante</h2>
+    <a href="${pageContext.request.contextPath}/app/non-existent">Test URL inexistante (devrait échouer avec 404)</a>
+</body>
+</html>


### PR DESCRIPTION
## Sprint 11 (Erreur 404 : Verbe non supporté)  

-  Envoyer un code de statut 404 lorsque le verbe n'est pas associé à l'URL spécifiée 